### PR TITLE
Changed headers and data for KvPatchMergeOperation

### DIFF
--- a/src/KvPatchMergeOperation.php
+++ b/src/KvPatchMergeOperation.php
@@ -4,4 +4,16 @@ namespace SocalNick\Orchestrate;
 
 class KvPatchMergeOperation extends KvPutOperation implements PatchOperationInterface
 {
+  public function getHeaders()
+  {
+    $headers = parent::getHeaders();
+    $headers['Content-Type'] = 'application/merge-patch+json';
+
+    return $headers;
+  }
+
+  public function getData()
+  {
+    return json_encode(parent::getData());
+  }
 }


### PR DESCRIPTION
As per the Orchestrate API, changed the Content-Type header for the JSON
partial merge operation to be application/merge-patch+json as opposed to
the standard application/json.

Also added manual JSON encoding of the body, since Guzzle will not do it
for you unless the Content-Type header is standard.

Fixes #14